### PR TITLE
ISSUE-3: Jammy is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,57 +4,80 @@ Retrieve the latest ubuntu (bionic, focal, and jammy) and convert to qcow2 forma
 
 # Test
 ```
-ubuntu@f0d07894491f:/jammy/packer$ PACKER_LOG=0 packer build ubuntu.pkr.hcl
+ubuntu@f0d07894491f:/jammy$ ./build.sh
 qemu.bionic: output will be in this color.
 qemu.focal: output will be in this color.
+qemu.jammy: output will be in this color.
 
+==> qemu.jammy: Retrieving ISO
 ==> qemu.focal: Retrieving ISO
 ==> qemu.bionic: Retrieving ISO
+==> qemu.jammy: Trying https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 ==> qemu.bionic: Trying https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
 ==> qemu.focal: Trying https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
 ==> qemu.bionic: Trying https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img?checksum=sha256%3A0a91d095b634d3a4e8eb042476e0bfc751168e69ae60f6b5885a006036508497
+==> qemu.jammy: Trying https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img?checksum=sha256%3A4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817
 ==> qemu.focal: Trying https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img?checksum=sha256%3A2591505cc6584a39bbab06d94491210dd406e2ed8a35d59f403acea60d4938a9
 ==> qemu.bionic: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img?checksum=sha256%3A0a91d095b634d3a4e8eb042476e0bfc751168e69ae60f6b5885a006036508497 => /home/ubuntu/.cache/packer/97d7101ddbc6aa2ec1af6c257961c84966bd2d9c.iso
 ==> qemu.bionic: Copying hard drive...
 ==> qemu.focal: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img?checksum=sha256%3A2591505cc6584a39bbab06d94491210dd406e2ed8a35d59f403acea60d4938a9 => /home/ubuntu/.cache/packer/7d9856cb66bc4b4cee0e739aa7cb65849b996da9.iso
 ==> qemu.focal: Copying hard drive...
+==> qemu.jammy: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img?checksum=sha256%3A4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817 => /home/ubuntu/.cache/packer/4cc086154a66a7a427a954917578e448a6a078ba.iso
+==> qemu.jammy: Copying hard drive...
 ==> qemu.bionic: Resizing hard drive...
 ==> qemu.focal: Resizing hard drive...
-==> qemu.bionic: Starting HTTP server on port 8765
-==> qemu.bionic: Found port for communicator (SSH, WinRM, etc): 4062.
+==> qemu.jammy: Resizing hard drive...
+==> qemu.bionic: Starting HTTP server on port 8135
+==> qemu.bionic: Found port for communicator (SSH, WinRM, etc): 4097.
 ==> qemu.bionic: Looking for available port between 5900 and 6000 on 127.0.0.1
 ==> qemu.bionic: Starting VM, booting disk image
 ==> qemu.bionic: Overriding default Qemu arguments with qemuargs template option...
-==> qemu.focal: Starting HTTP server on port 8655
-==> qemu.focal: Found port for communicator (SSH, WinRM, etc): 2284.
+==> qemu.jammy: Starting HTTP server on port 8191
+==> qemu.focal: Starting HTTP server on port 8676
+==> qemu.jammy: Found port for communicator (SSH, WinRM, etc): 3907.
+==> qemu.focal: Found port for communicator (SSH, WinRM, etc): 3030.
+==> qemu.jammy: Looking for available port between 5900 and 6000 on 127.0.0.1
 ==> qemu.focal: Looking for available port between 5900 and 6000 on 127.0.0.1
+==> qemu.jammy: Starting VM, booting disk image
+==> qemu.jammy: Overriding default Qemu arguments with qemuargs template option...
 ==> qemu.focal: Starting VM, booting disk image
 ==> qemu.focal: Overriding default Qemu arguments with qemuargs template option...
 ==> qemu.bionic: Waiting 3m0s for boot...
 ==> qemu.focal: Waiting 3m0s for boot...
-==> qemu.bionic: Connecting to VM via VNC (127.0.0.1:5937)
+==> qemu.jammy: Waiting 10s for boot...
+==> qemu.jammy: Connecting to VM via VNC (127.0.0.1:5920)
+==> qemu.jammy: Typing the boot command over VNC...
+    qemu.jammy: Not using a NetBridge -- skipping StepWaitGuestAddress
+==> qemu.jammy: Using SSH communicator to connect: 127.0.0.1
+==> qemu.jammy: Waiting for SSH to become available...
+==> qemu.bionic: Connecting to VM via VNC (127.0.0.1:5951)
 ==> qemu.bionic: Typing the boot command over VNC...
     qemu.bionic: Not using a NetBridge -- skipping StepWaitGuestAddress
 ==> qemu.bionic: Using SSH communicator to connect: 127.0.0.1
 ==> qemu.bionic: Waiting for SSH to become available...
-==> qemu.focal: Connecting to VM via VNC (127.0.0.1:5938)
+==> qemu.focal: Connecting to VM via VNC (127.0.0.1:5992)
 ==> qemu.focal: Typing the boot command over VNC...
     qemu.focal: Not using a NetBridge -- skipping StepWaitGuestAddress
 ==> qemu.focal: Using SSH communicator to connect: 127.0.0.1
 ==> qemu.focal: Waiting for SSH to become available...
 ==> qemu.bionic: Connected to SSH!
 ==> qemu.bionic: Gracefully halting virtual machine...
+==> qemu.jammy: Connected to SSH!
+==> qemu.jammy: Gracefully halting virtual machine...
 ==> qemu.focal: Connected to SSH!
 ==> qemu.focal: Gracefully halting virtual machine...
 ==> qemu.bionic: Converting hard drive...
+Build 'qemu.bionic' finished after 7 minutes 25 seconds.
 ==> qemu.focal: Converting hard drive...
-Build 'qemu.bionic' finished after 6 minutes 52 seconds.
-Build 'qemu.focal' finished after 7 minutes 25 seconds.
+==> qemu.jammy: Converting hard drive...
+Build 'qemu.focal' finished after 7 minutes 57 seconds.
+Build 'qemu.jammy' finished after 8 minutes 30 seconds.
 
-==> Wait completed after 7 minutes 25 seconds
+==> Wait completed after 8 minutes 30 seconds
 
 ==> Builds finished. The artifacts of successful builds are:
+--> qemu.jammy: VM files in directory: output
 --> qemu.bionic: VM files in directory: output
 --> qemu.focal: VM files in directory: output
-ubuntu@f0d07894491f:/jammy/packer$
+ubuntu@f0d07894491f:/jammy$
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,60 @@
 [![pre-commit](https://github.com/ibm-xaas/ubuntu-latest-jammy-to-qcow2/actions/workflows/pre-commit.yml/badge.svg?branch=main)](https://github.com/ibm-xaas/ubuntu-latest-jammy-to-qcow2/actions/workflows/pre-commit.yml)
 # ubuntu-latest-jammy-to-qcow2
-Retrieve the latest ubuntu (jammy) and convert to qcow2 format after removing unattended upgrades
+Retrieve the latest ubuntu (bionic, focal, and jammy) and convert to qcow2 format (after removing unattended upgrades)
+
+# Test
+```
+ubuntu@f0d07894491f:/jammy/packer$ PACKER_LOG=0 packer build ubuntu.pkr.hcl
+qemu.bionic: output will be in this color.
+qemu.focal: output will be in this color.
+
+==> qemu.focal: Retrieving ISO
+==> qemu.bionic: Retrieving ISO
+==> qemu.bionic: Trying https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
+==> qemu.focal: Trying https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+==> qemu.bionic: Trying https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img?checksum=sha256%3A0a91d095b634d3a4e8eb042476e0bfc751168e69ae60f6b5885a006036508497
+==> qemu.focal: Trying https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img?checksum=sha256%3A2591505cc6584a39bbab06d94491210dd406e2ed8a35d59f403acea60d4938a9
+==> qemu.bionic: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img?checksum=sha256%3A0a91d095b634d3a4e8eb042476e0bfc751168e69ae60f6b5885a006036508497 => /home/ubuntu/.cache/packer/97d7101ddbc6aa2ec1af6c257961c84966bd2d9c.iso
+==> qemu.bionic: Copying hard drive...
+==> qemu.focal: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img?checksum=sha256%3A2591505cc6584a39bbab06d94491210dd406e2ed8a35d59f403acea60d4938a9 => /home/ubuntu/.cache/packer/7d9856cb66bc4b4cee0e739aa7cb65849b996da9.iso
+==> qemu.focal: Copying hard drive...
+==> qemu.bionic: Resizing hard drive...
+==> qemu.focal: Resizing hard drive...
+==> qemu.bionic: Starting HTTP server on port 8765
+==> qemu.bionic: Found port for communicator (SSH, WinRM, etc): 4062.
+==> qemu.bionic: Looking for available port between 5900 and 6000 on 127.0.0.1
+==> qemu.bionic: Starting VM, booting disk image
+==> qemu.bionic: Overriding default Qemu arguments with qemuargs template option...
+==> qemu.focal: Starting HTTP server on port 8655
+==> qemu.focal: Found port for communicator (SSH, WinRM, etc): 2284.
+==> qemu.focal: Looking for available port between 5900 and 6000 on 127.0.0.1
+==> qemu.focal: Starting VM, booting disk image
+==> qemu.focal: Overriding default Qemu arguments with qemuargs template option...
+==> qemu.bionic: Waiting 3m0s for boot...
+==> qemu.focal: Waiting 3m0s for boot...
+==> qemu.bionic: Connecting to VM via VNC (127.0.0.1:5937)
+==> qemu.bionic: Typing the boot command over VNC...
+    qemu.bionic: Not using a NetBridge -- skipping StepWaitGuestAddress
+==> qemu.bionic: Using SSH communicator to connect: 127.0.0.1
+==> qemu.bionic: Waiting for SSH to become available...
+==> qemu.focal: Connecting to VM via VNC (127.0.0.1:5938)
+==> qemu.focal: Typing the boot command over VNC...
+    qemu.focal: Not using a NetBridge -- skipping StepWaitGuestAddress
+==> qemu.focal: Using SSH communicator to connect: 127.0.0.1
+==> qemu.focal: Waiting for SSH to become available...
+==> qemu.bionic: Connected to SSH!
+==> qemu.bionic: Gracefully halting virtual machine...
+==> qemu.focal: Connected to SSH!
+==> qemu.focal: Gracefully halting virtual machine...
+==> qemu.bionic: Converting hard drive...
+==> qemu.focal: Converting hard drive...
+Build 'qemu.bionic' finished after 6 minutes 52 seconds.
+Build 'qemu.focal' finished after 7 minutes 25 seconds.
+
+==> Wait completed after 7 minutes 25 seconds
+
+==> Builds finished. The artifacts of successful builds are:
+--> qemu.bionic: VM files in directory: output
+--> qemu.focal: VM files in directory: output
+ubuntu@f0d07894491f:/jammy/packer$
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+./create_locald.sh
+cd packer
+rm -rf output
+PACKER_LOG=0 packer init ubuntu.pkr.hcl
+PACKER_LOG=0 packer build ubuntu.pkr.hcl

--- a/create_locald.sh
+++ b/create_locald.sh
@@ -6,24 +6,6 @@ ssh_authorized_keys:
   - "${public_key}"
 EOF
 
-cat <<EOF > user-data-jammy
-#cloud-config
-autoinstall:
-  version: 1
-  identity:
-    hostname: ubuntu
-    username: ubuntu
-    password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
-  ssh:
-    install-server: yes
-    authorized-keys:
-      - "${public_key}"
-EOF
 cloud-localds packer/disk-ssh-pub-focal.img user-data
 cloud-localds packer/disk-ssh-pub-bionic.img user-data
-cp user-data-jammy packer/http/user-data
-#jammy trial: failed 10/19/22
-#rm -f user-data
-#cp user-data-jammy user-data
-#touch meta-data
-#cloud-localds packer/disk-ssh-pub-jammy.img user-data meta-data
+cloud-localds packer/disk-ssh-pub-jammy.img user-data

--- a/packer/ubuntu.pkr.hcl
+++ b/packer/ubuntu.pkr.hcl
@@ -1,14 +1,13 @@
 source "qemu" "jammy" {
-  iso_url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-  iso_checksum     = "file:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"
-  output_directory = "output"
-  shutdown_command = "rm -f /home/ubuntu/.ssh/authorized_keys && sudo rm -f /root/.ssh/authorized_keys && echo 'packer' | sudo -S shutdown -P now"
-  disk_size        = "10G"
-  format           = "qcow2"
-  http_directory   = "http"
-  ssh_username     = "ubuntu"
-  ssh_password     = "ubuntu" # pragma: allowlist secret
-  #ssh_private_key_file      = "~/.ssh/id_ed25519"
+  iso_url                   = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  iso_checksum              = "file:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"
+  output_directory          = "output"
+  shutdown_command          = "rm -f /home/ubuntu/.ssh/authorized_keys && sudo rm -f /root/.ssh/authorized_keys && echo 'packer' | sudo -S shutdown -P now"
+  disk_size                 = "10G"
+  format                    = "qcow2"
+  http_directory            = "http"
+  ssh_username              = "ubuntu"
+  ssh_private_key_file      = "~/.ssh/id_ed25519"
   ssh_port                  = 22
   ssh_clear_authorized_keys = true
   ssh_timeout               = "60m"
@@ -20,7 +19,7 @@ source "qemu" "jammy" {
   vm_name                   = "jammy"
   qemuargs = [
     ["-display", "none"],
-    ["-fda", "disk-ssh-pub-jammy.img"]
+    ["-cdrom", "disk-ssh-pub-jammy.img"]
   ]
 }
 
@@ -45,7 +44,7 @@ source "qemu" "focal" {
   vm_name                   = "focal"
   qemuargs = [
     ["-display", "none"],
-    ["-fda", "disk-ssh-pub-focal.img"]
+    ["-cdrom", "disk-ssh-pub-jammy.img"]
   ]
 }
 
@@ -70,13 +69,13 @@ source "qemu" "bionic" {
   vm_name                   = "bionic"
   qemuargs = [
     ["-display", "none"],
-    ["-fda", "disk-ssh-pub-bionic.img"]
+    ["-cdrom", "disk-ssh-pub-jammy.img"]
   ]
 }
 
 
 build {
-  sources = ["source.qemu.bionic", "source.qemu.focal"]
+  sources = ["source.qemu.bionic", "source.qemu.focal", "source.qemu.jammy"]
   #sources = ["source.qemu.jammy"]
   #sources = ["source.qemu.bionic"]
   #sources = ["source.qemu.focal"]


### PR DESCRIPTION
[ISSUE-3](https://github.com/ibm-xaas/ubuntu-latest-jammy-to-qcow2/issues/3) is done.

#Test
```
ubuntu@f0d07894491f:/jammy$ ./build.sh
qemu.bionic: output will be in this color.
qemu.focal: output will be in this color.
qemu.jammy: output will be in this color.
==> qemu.jammy: Retrieving ISO
==> qemu.focal: Retrieving ISO
==> qemu.bionic: Retrieving ISO
==> qemu.jammy: Trying https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
==> qemu.bionic: Trying https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
==> qemu.focal: Trying https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
==> qemu.bionic: Trying https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img?checksum=sha256%3A0a91d095b634d3a4e8eb042476e0bfc751168e69ae60f6b5885a006036508497
==> qemu.jammy: Trying https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img?checksum=sha256%3A4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817
==> qemu.focal: Trying https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img?checksum=sha256%3A2591505cc6584a39bbab06d94491210dd406e2ed8a35d59f403acea60d4938a9
==> qemu.bionic: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img?checksum=sha256%3A0a91d095b634d3a4e8eb042476e0bfc751168e69ae60f6b5885a006036508497 => /home/ubuntu/.cache/packer/97d7101ddbc6aa2ec1af6c257961c84966bd2d9c.iso
==> qemu.bionic: Copying hard drive...
==> qemu.focal: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img?checksum=sha256%3A2591505cc6584a39bbab06d94491210dd406e2ed8a35d59f403acea60d4938a9 => /home/ubuntu/.cache/packer/7d9856cb66bc4b4cee0e739aa7cb65849b996da9.iso
==> qemu.focal: Copying hard drive...
==> qemu.jammy: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img?checksum=sha256%3A4d8d5b95082ed3551cf06b086b854b99d2025c903d1936c35ef34e173c57a817 => /home/ubuntu/.cache/packer/4cc086154a66a7a427a954917578e448a6a078ba.iso
==> qemu.jammy: Copying hard drive...
==> qemu.bionic: Resizing hard drive...
==> qemu.focal: Resizing hard drive...
==> qemu.jammy: Resizing hard drive...
==> qemu.bionic: Starting HTTP server on port 8135
==> qemu.bionic: Found port for communicator (SSH, WinRM, etc): 4097.
==> qemu.bionic: Looking for available port between 5900 and 6000 on 127.0.0.1
==> qemu.bionic: Starting VM, booting disk image
==> qemu.bionic: Overriding default Qemu arguments with qemuargs template option...
==> qemu.jammy: Starting HTTP server on port 8191
==> qemu.focal: Starting HTTP server on port 8676
==> qemu.jammy: Found port for communicator (SSH, WinRM, etc): 3907.
==> qemu.focal: Found port for communicator (SSH, WinRM, etc): 3030.
==> qemu.jammy: Looking for available port between 5900 and 6000 on 127.0.0.1
==> qemu.focal: Looking for available port between 5900 and 6000 on 127.0.0.1
==> qemu.jammy: Starting VM, booting disk image
==> qemu.jammy: Overriding default Qemu arguments with qemuargs template option...
==> qemu.focal: Starting VM, booting disk image
==> qemu.focal: Overriding default Qemu arguments with qemuargs template option...
==> qemu.bionic: Waiting 3m0s for boot...
==> qemu.focal: Waiting 3m0s for boot...
==> qemu.jammy: Waiting 10s for boot...
==> qemu.jammy: Connecting to VM via VNC (127.0.0.1:5920)
==> qemu.jammy: Typing the boot command over VNC...
    qemu.jammy: Not using a NetBridge -- skipping StepWaitGuestAddress
==> qemu.jammy: Using SSH communicator to connect: 127.0.0.1
==> qemu.jammy: Waiting for SSH to become available...
==> qemu.bionic: Connecting to VM via VNC (127.0.0.1:5951)
==> qemu.bionic: Typing the boot command over VNC...
    qemu.bionic: Not using a NetBridge -- skipping StepWaitGuestAddress
==> qemu.bionic: Using SSH communicator to connect: 127.0.0.1
==> qemu.bionic: Waiting for SSH to become available...
==> qemu.focal: Connecting to VM via VNC (127.0.0.1:5992)
==> qemu.focal: Typing the boot command over VNC...
    qemu.focal: Not using a NetBridge -- skipping StepWaitGuestAddress
==> qemu.focal: Using SSH communicator to connect: 127.0.0.1
==> qemu.focal: Waiting for SSH to become available...
==> qemu.bionic: Connected to SSH!
==> qemu.bionic: Gracefully halting virtual machine...
==> qemu.jammy: Connected to SSH!
==> qemu.jammy: Gracefully halting virtual machine...
==> qemu.focal: Connected to SSH!
==> qemu.focal: Gracefully halting virtual machine...
==> qemu.bionic: Converting hard drive...
Build 'qemu.bionic' finished after 7 minutes 25 seconds.
==> qemu.focal: Converting hard drive...
==> qemu.jammy: Converting hard drive...
Build 'qemu.focal' finished after 7 minutes 57 seconds.
Build 'qemu.jammy' finished after 8 minutes 30 seconds.
==> Wait completed after 8 minutes 30 seconds
==> Builds finished. The artifacts of successful builds are:
--> qemu.jammy: VM files in directory: output
--> qemu.bionic: VM files in directory: output
--> qemu.focal: VM files in directory: output
ubuntu@f0d07894491f:/jammy$
```